### PR TITLE
Add version to formula

### DIFF
--- a/octopuscli.rb
+++ b/octopuscli.rb
@@ -1,6 +1,7 @@
 class Octopuscli < Formula
   desc "The Octopus CLI (octo) for Octopus, a user-friendly DevOps tool for developers that supports release management, deployment automation, and operations runbooks"
   homepage "https://github.com/OctopusDeploy/OctopusCLI"
+  version "7.2.0"
   url "https://octopus-downloads.s3-eu-west-1.amazonaws.com/octopus-tools/7.2.0/OctopusTools.7.2.0.osx-x64.tar.gz"
   sha256 "4fdc3b4caf707d121ffd359f7ee18685645395ab18d443410001b7f0a7bee19d"
 


### PR DESCRIPTION
There is no version specified in the formula. Homebrew is calculating the version as `64`. This version does not change when new versions are updated in the formula URL. I had `7.1.3` installed. It did not download and install the latest version `7.2.0` when I did a `brew upgrade`. I had to do a `brew reinstall octopuscli` to update to `7.2.0`. I believe adding the version should fix brew showing the correct version and updating it when future releases are made.