### PR TITLE
Add version to formula

### DIFF
--- a/octopuscli.rb
+++ b/octopuscli.rb
@@ -1,6 +1,7 @@
 class Octopuscli < Formula
   desc "The Octopus CLI (octo) for Octopus, a user-friendly DevOps tool for developers that supports release management, deployment automation, and operations runbooks"
   homepage "https://github.com/OctopusDeploy/OctopusCLI"
+  version "7.3.1"
   url "https://octopus-downloads.s3-eu-west-1.amazonaws.com/octopus-tools/7.3.1/OctopusTools.7.3.1.osx-x64.tar.gz"
   sha256 "66e7251206ac35fa4435fa0edabe4d4f0d985af40f96177217372f7223b25767"
 


### PR DESCRIPTION
There is no version specified in the formula. Homebrew is calculating the version as 64. This version does not change when new versions are updated in the formula URL. I had 7.1.3 installed. It did not download and install the latest version 7.2.0 when I did a brew upgrade. I had to do a brew reinstall octopuscli to update to 7.2.0. I believe adding the version should fix brew showing the correct version and updating it when future releases are made.